### PR TITLE
add support for image sha digets in addition to normal tags

### DIFF
--- a/stable/configmap-watcher/templates/deployment.yaml
+++ b/stable/configmap-watcher/templates/deployment.yaml
@@ -38,7 +38,11 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.imageShaDigests.first_image }}
+          image: "{{ .Values.image.repository }}/{{ .Values.image.name }}@{{ .Values.imageShaDigests.configmap_watcher }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}{{ .Values.imageTagPostfix }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v={{ .Values.args.verbosity }}

--- a/stable/configmap-watcher/values.yaml
+++ b/stable/configmap-watcher/values.yaml
@@ -10,6 +10,9 @@ image:
   tag: 3.3.1
   pullPolicy: IfNotPresent
 
+imageShaDigests:
+  configmap_watcher: ""
+
 args:
   verbosity: 0
   cleanFreq:


### PR DESCRIPTION
This allows the installer to use image sha digests instead of tags for this chart.
Issue: https://github.com/open-cluster-management/backlog/issues/1544