### PR TITLE
didn't update the sha digest image name after copy paste

### DIFF
--- a/stable/configmap-watcher/templates/deployment.yaml
+++ b/stable/configmap-watcher/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.imageShaDigests.first_image }}
+          {{- if .Values.imageShaDigests.configmap_watcher }}
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}@{{ .Values.imageShaDigests.configmap_watcher }}"
           {{- else }}
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}{{ .Values.imageTagPostfix }}"


### PR DESCRIPTION
I missed an update after copy pasting the changes for image sha digest support.